### PR TITLE
Revert "Fix how zoom level is interpreted"

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -291,11 +291,6 @@ export default function(olLayer, glStyle, source, resolutions, spriteData, sprit
     if (zoom == -1) {
       zoom = getZoomForResolution(resolution, resolutions);
     }
-    if (zoom > 0) {
-      // mapbox zoom level is counted from 0 to X, OL zoom level is counted from 1 to X
-      // so here we substract 1 to adjust to zoom level described in Mapbox Style
-      zoom -= 1;
-    }
     const type = types[feature.getGeometry().getType()];
     const f = {
       properties: properties,


### PR DESCRIPTION
Reverts geoadmin/ol-mapbox-style#3

This has not fixed correctly this issue, plus now that we have `letter-spacing` and `text-padding` implemented, this might not be a big issue anymore