### PR TITLE
Text-halo : take text size into account

### DIFF
--- a/stylefunction.js
+++ b/stylefunction.js
@@ -636,7 +636,7 @@ export default function(olLayer, glStyle, source, resolutions = defaultResolutio
           const haloColor = colorWithOpacity(getValue(layer, 'paint', 'text-halo-color', zoom, f), opacity);
           if (haloColor) {
             textHalo.setColor(haloColor);
-            textHalo.setWidth(getValue(layer, 'paint', 'text-halo-width', zoom, f));
+            textHalo.setWidth(getValue(layer, 'paint', 'text-halo-width', zoom, f) + 0.1 * textSize);
             text.setStroke(textHalo);
           } else {
             text.setStroke(undefined);


### PR DESCRIPTION
OLMS tackle this feature by creating a ol/style/Stroke behind the text, this doesn't mimic CSS text-shadow (as seems to be implemented in Mapbox) because it doesn't count the shadowed text width.
This is an attempt to get closer to the CSS rendering with text-shadow used in Mapbox.